### PR TITLE
3 patches vnc, sha-bang and correct removal of directories

### DIFF
--- a/testCloud.py
+++ b/testCloud.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright 2014, Red Hat, Inc.
 # License: GPL-2.0+ <http://spdx.org/licenses/GPL-2.0+>


### PR DESCRIPTION
Added:
1. Remove /tmp/testCloud if only it exists.
2. --vnc command line argument for vnc console.
3. Adds a sha-bang line and makes it executable.
