### PR TITLE
refactoring config to allow for config files outside the source tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 #*#
 *.swp
+conf/settings.py

--- a/README.rst
+++ b/README.rst
@@ -35,11 +35,12 @@ After installing via pip or setup.py, you can run
 There are currently only three options (all optional) you can use when invoking
 this script: '--ram', '--no-graphic' and '--atomic'.
 
-The --ram option takes an int for how much ram you want the guest to have, the --no-graphic option is merely a flag to suppress a GUI from appearing,
-the --atomic option indicates that you wish to boot an 
-`Atomic <http://projectatomic.io>`_ host as well as "--pristine", which allows you
+The --ram option takes an int for how much ram you want the guest to have, the
+``--no-graphic option`` is merely a flag to suppress a GUI from appearing, the
+``--atomic`` option indicates that you wish to boot an
+`Atomic <http://projectatomic.io>`_ host as well as ``--pristine``, which allows you
 to reuse a previously downloaded image regardless of whether it's been
-configured before (reusing an image without "--pristine" still boots as 
+configured before (reusing an image without ``--pristine`` still boots as 
 expectedi, retaining any configuration done to it previously).
 
 Once the image has booted, you can log in from the GUI or ssh. To log in with 
@@ -52,6 +53,22 @@ ssh, run the following command:
 The user is 'fedora' and the password is 'passw0rd'
 
 Now you have a working local cloud image to test against.
+
+Configuration
+-------------
+
+The default configuration should work for many people but those defaults can
+be overridden through the use of a ``settings.py`` file containing the values to
+use when overriding default settings. The example file in
+``conf/settings-example.py`` shows the possible configuration values which can
+be changed.
+
+Note that in order for those new values to be picked up, the filename must be
+``settings.py`` and that file must live in one of the following locations:
+
+- ``conf/settings.py`` in the git checkout
+- ``~/.config/testCloud/settings.py``
+- ``/etc/testCloud/settings.py``
 
 Testing
 -------

--- a/conf/settings-example.py
+++ b/conf/settings-example.py
@@ -1,0 +1,48 @@
+import os
+
+
+# Commented out default values with details are displayed below. To override
+# these default values, uncomment the values, rename the file to settings.py
+# and place it in a supported config location
+
+# Do not modify this file directly, it will not be picked up unless the filename
+# is changed to settings.py
+
+#DOWNLOAD_PROGRESS = True
+
+# Directories testCloud cares about
+
+#PRISTINE = "/home/{}/.cache/testcloud/images/".format(os.getlogin())
+#LOCAL_DOWNLOAD_DIR = "/var/tmp/"
+
+# Data for cloud-init
+
+#PASSWORD = 'passw0rd'
+#HOSTNAME = 'testcloud'
+
+#META_DATA = """instance-id: iid-123456
+#local-hostname: %s
+#"""
+#USER_DATA = """#cloud-config
+#password: %s
+#chpasswd: { expire: False }
+#ssh_pwauth: True
+#"""
+#ATOMIC_USER_DATA = """#cloud-config
+#password: %s
+#chpasswd: { expire: False }
+#ssh_pwauth: True
+#runcmd:
+#  - [ sh, -c, 'echo -e "ROOT_SIZE=4G\nDATA_SIZE=10G" > /etc/sysconfig/docker-storage-setup']
+#"""
+#
+# Extra cmdline args for the qemu invocation.
+# Customize as needed :)
+
+#CMD_LINE_ARGS = ['-redir',
+#                 'tcp:2222::22',
+#                 '-redir',
+#                 'tcp:8888::80',
+#                 '-smp',
+#                 '2'
+#                 ]

--- a/testCloud/cli.py
+++ b/testCloud/cli.py
@@ -14,6 +14,7 @@ import config
 import util
 import libtestcloud as libtc
 
+config_data = config.get_config()
 
 def run(
     image_url, ram=512, graphics=False, vnc=False, atomic=False,
@@ -24,12 +25,12 @@ def run(
     util.clean_dirs()
     util.create_dirs()
 
-    base_path = config.LOCAL_DOWNLOAD_DIR + '/testCloud'
+    base_path = config_data.LOCAL_DOWNLOAD_DIR + '/testCloud'
 
     # Create the data cloud-init needs
     print "Creating meta-data..."
-    util.create_user_data(base_path, "passw0rd", atomic=atomic)
-    util.create_meta_data(base_path, "testcloud")
+    util.create_user_data(base_path, config_data.PASSWORD, atomic=atomic)
+    util.create_meta_data(base_path, config_data.HOSTNAME)
 
     # Instantiate the image and the instance from the image
 
@@ -45,7 +46,7 @@ def run(
 
     vm.create_seed_image(base_path + '/meta', base_path)
 
-    if not os.path.isfile(config.PRISTINE + vm.image):
+    if not os.path.isfile(config_data.PRISTINE + vm.image):
         print "downloading new image..."
         image.download()
         image.save_pristine()

--- a/testCloud/config.py
+++ b/testCloud/config.py
@@ -1,38 +1,132 @@
 import os
+import imp
+
+import testCloud
 
 
-DOWNLOAD_PROGRESS = True
+CONF_DIRS = [os.path.abspath(os.path.dirname(testCloud.__file__)) + '/../conf',
+             '{}/.config/testCloud'.format(os.environ['HOME']),
+             '/etc/testCloud'
+             ]
 
-# Directories testCloud cares about
+CONF_FILE = 'settings.py'
 
-PRISTINE = "/home/{}/.cache/testcloud/images/".format(os.getlogin())
-LOCAL_DOWNLOAD_DIR = "/var/tmp/"
+_config = None
 
-# Data for cloud-init
+def get_config():
+    '''Retrieve a config instance. If a config instance has already been parsed,
+    reuse that parsed instance.
 
-META_DATA = """instance-id: iid-123456
+    :return: :class:`.ConfigData` containing configuration values
+    '''
+
+    global _config
+    if not _config:
+        _config = _parse_config()
+    return _config
+
+
+def _parse_config():
+    '''Parse config file in a supported location and merge with default values.
+
+    :return: loaded config data merged with defaults from :class:`.ConfigData`
+    '''
+
+    config = ConfigData()
+    config_filename = _find_config_file()
+
+    if config_filename is not None:
+        loaded_config = _load_config(config_filename)
+        config.merge_object(loaded_config)
+
+    return config
+
+
+def _find_config_file():
+    '''Look in supported config dirs for a configuration file.
+
+    :return: filename of first discovered file, None if no files are found
+    '''
+
+    for conf_dir in CONF_DIRS:
+        conf_file = '{}/{}'.format(conf_dir, CONF_FILE)
+        if os.path.exists(conf_file):
+            return conf_file
+    return None
+
+
+def _load_config(conf_filename):
+    '''Load configuration data from a python file. Only loads attrs which are
+    named using all caps.
+
+    :param conf_filename: full path to config file to load
+    :type conf_filename: str
+    :return: object containing configuration values
+    '''
+
+    new_conf = imp.new_module('config')
+    new_conf.__file__ = conf_filename
+    try:
+        with open(conf_filename, 'r') as conf_file:
+            exec(compile(conf_file.read(), conf_filename, 'exec'),
+                    new_conf.__dict__)
+    except IOError as e:
+        e.strerror = 'Unable to load config file {}'.format(e.strerror)
+        raise
+    return new_conf
+
+class ConfigData(object):
+    '''Holds configuration data for TestCloud. Is initialized with default
+    values which can be overridden.
+    '''
+
+    DOWNLOAD_PROGRESS = True
+
+    # Directories testCloud cares about
+
+    PRISTINE = "/home/{}/.cache/testcloud/images/".format(os.getlogin())
+    LOCAL_DOWNLOAD_DIR = "/var/tmp/"
+
+    # Data for cloud-init
+
+    PASSWORD = 'passw0rd'
+    HOSTNAME = 'testcloud'
+
+    META_DATA = """instance-id: iid-123456
 local-hostname: %s
-"""
-USER_DATA = """#cloud-config
+    """
+    USER_DATA = """#cloud-config
 password: %s
 chpasswd: { expire: False }
 ssh_pwauth: True
-"""
-ATOMIC_USER_DATA = """#cloud-config
+    """
+    ATOMIC_USER_DATA = """#cloud-config
 password: %s
 chpasswd: { expire: False }
 ssh_pwauth: True
 runcmd:
   - [ sh, -c, 'echo -e "ROOT_SIZE=4G\nDATA_SIZE=10G" > /etc/sysconfig/docker-storage-setup']
-"""
+    """
 
-# Extra cmdline args for the qemu invocation.
-# Customize as needed :)
+    # Extra cmdline args for the qemu invocation.
+    # Customize as needed :)
 
-CMD_LINE_ARGS = ['-redir',
-                 'tcp:2222::22',
-                 '-redir',
-                 'tcp:8888::80',
-                 '-smp',
-                 '2'
-                 ]
+    CMD_LINE_ARGS = ['-redir',
+                     'tcp:2222::22',
+                     '-redir',
+                     'tcp:8888::80',
+                     '-smp',
+                     '2'
+                     ]
+
+    def merge_object(self, obj):
+        '''Overwrites default values with values from a python object which have
+        names containing all upper case letters.
+
+        :param obj: python object containing configuration values
+        :type obj: python object
+        '''
+
+        for key in dir(obj):
+            if key.isupper():
+                setattr(self, key, getattr(obj, key))

--- a/testCloud/libtestcloud.py
+++ b/testCloud/libtestcloud.py
@@ -17,6 +17,8 @@ import config
 import urllib2
 
 
+config_data = config.get_config()
+
 class Image(object):
     """The Image class handles the download, storage and retrieval of
     cloud images."""
@@ -24,7 +26,7 @@ class Image(object):
     def __init__(self, url):
         self.url = url
         self.name = url.split('/')[-1]
-        self.path = config.LOCAL_DOWNLOAD_DIR + self.name
+        self.path = config_data.LOCAL_DOWNLOAD_DIR + self.name
 
     def download(self):
         """ Downloads files (qcow2s, specifically) from a list of URLs with an
@@ -35,11 +37,11 @@ class Image(object):
         # with a sign saying "FREE." Thanks oddshocks!
 
         # Create the proper local upload directory if it doesn't exist.
-        if not os.path.exists(config.LOCAL_DOWNLOAD_DIR):
-            os.makedirs(config.LOCAL_DOWNLOAD_DIR)
+        if not os.path.exists(config_data.LOCAL_DOWNLOAD_DIR):
+            os.makedirs(config_data.LOCAL_DOWNLOAD_DIR)
 
         print "Local downloads will be stored in {}.".format(
-            config.LOCAL_DOWNLOAD_DIR)
+            config_data.LOCAL_DOWNLOAD_DIR)
 
         # When qcow2s are downloaded and converted, they are added here
         raw_files = list()
@@ -49,7 +51,7 @@ class Image(object):
 
         for url in list(urls):
             file_name = url.split('/')[-1]
-        local_file_name = config.LOCAL_DOWNLOAD_DIR + file_name
+        local_file_name = config_data.LOCAL_DOWNLOAD_DIR + file_name
         u = urllib2.urlopen(url)
 
         try:
@@ -73,7 +75,7 @@ class Image(object):
                     bytes_downloaded += len(buff)
                     f.write(buff)
                     bytes_remaining = float(bytes_downloaded) / file_size
-                    if config.DOWNLOAD_PROGRESS:
+                    if config_data.DOWNLOAD_PROGRESS:
                         # TODO: Improve this progress indicator by making
                         # it more readable and user-friendly.
                         status = r"{0} [{1:.2%}]".format(bytes_downloaded,
@@ -82,27 +84,27 @@ class Image(object):
                         sys.stdout.write(status)
 
         except OSError:
-            print "Problem writing to {}.".format(config.LOCAL_DOWNLOAD_DIR)
+            print "Problem writing to {}.".format(config_data.LOCAL_DOWNLOAD_DIR)
 
     def save_pristine(self):
-        """Save a copy of the downloaded image to the configured PRISTINE dir.
+        """Save a copy of the downloaded image to the config_dataured PRISTINE dir.
         Only call this after an image has been downloaded.
         """
 
         subprocess.call(['cp',
                         self.path,
-                        config.PRISTINE])
+                        config_data.PRISTINE])
 
-        print 'Copied fresh image to {0}...'.format(config.PRISTINE)
+        print 'Copied fresh image to {0}...'.format(config_data.PRISTINE)
 
     def load_pristine(self):
         """Load a pristine image to /tmp instead of downloading.
         """
         subprocess.call(['cp',
-                         config.PRISTINE + self.name,
-                         config.LOCAL_DOWNLOAD_DIR])
+                         config_data.PRISTINE + self.name,
+                         config_data.LOCAL_DOWNLOAD_DIR])
 
-        print 'Copied fresh image to {} ...'.format(config.LOCAL_DOWNLOAD_DIR)
+        print 'Copied fresh image to {} ...'.format(config_data.LOCAL_DOWNLOAD_DIR)
 
 
 class Instance(object):
@@ -153,7 +155,7 @@ class Instance(object):
         """Set the seed image for the instance."""
         self.seed = path
 
-    def download_initrd_and_kernel(self, path=config.LOCAL_DOWNLOAD_DIR):
+    def download_initrd_and_kernel(self, path=config_data.LOCAL_DOWNLOAD_DIR):
         """Download the necessary kernel and initrd for booting a specified
         cloud image."""
 
@@ -184,8 +186,8 @@ class Instance(object):
                      'file=%s,if=virtio' % self.seed,
                      ]
 
-        # Extend with the customizations from the config file
-        boot_args.extend(config.CMD_LINE_ARGS)
+        # Extend with the customizations from the config_data file
+        boot_args.extend(config_data.CMD_LINE_ARGS)
 
         if self.atomic:
             self.expand_qcow()

--- a/testCloud/util.py
+++ b/testCloud/util.py
@@ -15,6 +15,8 @@ import glob
 import config
 
 
+config_data = config.get_config()
+
 def create_user_data(path, password, overwrite=False, atomic=False):
     """Save the right  password to the 'user-data' file needed to
     emulate cloud-init. Default username on cloud images is "fedora"
@@ -23,10 +25,10 @@ def create_user_data(path, password, overwrite=False, atomic=False):
     the overwrite kwarg is set to True."""
 
     if atomic:
-        file_data = config.ATOMIC_USER_DATA % password
+        file_data = config_data.ATOMIC_USER_DATA % password
 
     else:
-        file_data = config.USER_DATA % password
+        file_data = config_data.USER_DATA % password
 
     if os.path.isfile(path + '/meta/user-data'):
         if overwrite:
@@ -51,7 +53,7 @@ def create_meta_data(path, hostname, overwrite=False):
     Will not overwrite an existing user-data file unless
     the overwrite kwarg is set to True."""
 
-    file_data = config.META_DATA % hostname
+    file_data = config_data.META_DATA % hostname
 
     if os.path.isfile(path + '/meta/meta-data'):
         if overwrite:
@@ -71,22 +73,22 @@ def create_meta_data(path, hostname, overwrite=False):
 
 def create_dirs():
     """Create the dirs in the download dir we need to store things."""
-    os.makedirs(config.LOCAL_DOWNLOAD_DIR + 'testCloud/meta')
-    if not os.path.exists(config.PRISTINE):
-        os.makedirs(config.PRISTINE)
-        print "Created image store: {0}".format(config.PRISTINE)
+    os.makedirs(config_data.LOCAL_DOWNLOAD_DIR + 'testCloud/meta')
+    if not os.path.exists(config_data.PRISTINE):
+        os.makedirs(config_data.PRISTINE)
+        print "Created image store: {0}".format(config_data.PRISTINE)
     return "Created tmp directories."
 
 
 def clean_dirs():
     """Remove dirs after a test run."""
-    if os.path.exists(config.LOCAL_DOWNLOAD_DIR + 'testCloud'):
-        shutil.rmtree(config.LOCAL_DOWNLOAD_DIR + 'testCloud')
+    if os.path.exists(config_data.LOCAL_DOWNLOAD_DIR + 'testCloud'):
+        shutil.rmtree(config_data.LOCAL_DOWNLOAD_DIR + 'testCloud')
     return "All cleaned up!"
 
 
 def list_pristine():
     """List the pristine images currently saved."""
-    images = glob.glob(config.PRISTINE + '/*')
+    images = glob.glob(config_data.PRISTINE + '/*')
     for image in images:
         print '\t- {0}'.format(image.split('/')[-1])


### PR DESCRIPTION
This changes the way config works so that the defaults are stored in the source tree but anything overriding those defaults lives outside of the source tree. I also changed the VM's hostname and password to be configurable.

The config changes for users are described in the README