### PR TITLE
Look for the jinja template in the conf/ dir first

### DIFF
--- a/testcloud/config.py
+++ b/testcloud/config.py
@@ -4,7 +4,9 @@ import imp
 import testcloud
 
 
-CONF_DIRS = [os.path.abspath(os.path.dirname(testcloud.__file__)) + '/../conf',
+DEFAULT_CONF_DIR = os.path.abspath(os.path.dirname(testcloud.__file__)) + '/../conf'
+
+CONF_DIRS = [DEFAULT_CONF_DIR,
              '{}/.config/testcloud'.format(os.environ['HOME']),
              '/etc/testcloud'
              ]
@@ -91,7 +93,7 @@ class ConfigData(object):
     STORE_DIR = "/var/lib/testcloud/backingstores"
 
     # libvirt domain XML Template
-    # This lives in the DATA_DIR
+    # This lives either in the DEFAULT_CONF_DIR or DATA_DIR
     XML_TEMPLATE = "domain-template.jinja"
 
     # Data for cloud-init

--- a/testcloud/instance.py
+++ b/testcloud/instance.py
@@ -311,7 +311,8 @@ class Instance(object):
         """
 
         # Set up the jinja environment
-        jinjaLoader = jinja2.FileSystemLoader(searchpath=config_data.DATA_DIR)
+        jinjaLoader = jinja2.FileSystemLoader(searchpath=[config.DEFAULT_CONF_DIR,
+                                                          config_data.DATA_DIR])
         jinjaEnv = jinja2.Environment(loader=jinjaLoader)
         xml_template = jinjaEnv.get_template(config_data.XML_TEMPLATE)
 


### PR DESCRIPTION
This way there is no need to copy the jinja template into
/var/lib/testcloud when running testcloud from git.

Originally reviewed at https://phab.qadevel.cloud.fedoraproject.org/D967.